### PR TITLE
Soften Rails dependency to 4.2.0

### DIFF
--- a/active_waiter.gemspec
+++ b/active_waiter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.2.1"
+  s.add_dependency "rails", "~> 4.2.0"
   s.add_dependency "jquery-rails"
   s.add_dependency "turbolinks"
 


### PR DESCRIPTION
Since ActiveJob introduced in 4.2.0. We should allow people on 4.2.0 boat to use this gem.
