### PR TITLE
Lightweight released gem

### DIFF
--- a/active_waiter.gemspec
+++ b/active_waiter.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 4.2.1"
   s.add_dependency "jquery-rails"


### PR DESCRIPTION
From 230KB => 9KB

Since people clone & develop on their local machine. Let's not pack tests into released `active_waiter.gem` to save world environment (less bandwidth used to download, consume less disk space, faster bundle install).
