### PR TITLE
Add support for customizing the shared cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ Next, prefix any routes used in your application's layout with `main_app.`, e.g.
 This is required because `ActiveWaiter` is a Rails Engine mounted into your application,
 and it doesn't know about the routes declared within your application.
 
+#### Changing the shared cache
+
+For deploying in production environments, `ActiveWaiter` requires a shared cache to
+track the status of downloads. By default it uses the Rails cache. If you want to
+use something else other than the Rails cache like redis for example, you may specify
+your own implementation:
+
+```ruby
+class RedisStore
+  def write(uid, value)
+    $redis.set("active_waiter:#{uid}", value)
+  end
+
+  def read(uid)
+    $redis.get("active_waiter:#{uid}")
+  end
+end
+
+ActiveWaiter.configure do |config|
+  config.store = RedisStore.new
+end
+```
+
 #### Exceptions
 
 When your job gets an exception, the error message will be written in the error message and passed along

--- a/lib/active_waiter.rb
+++ b/lib/active_waiter.rb
@@ -1,4 +1,5 @@
 require "active_waiter/engine"
+require "active_waiter/store"
 require "active_waiter/configuration"
 require "active_waiter/job"
 require "active_waiter/enumerable_job"
@@ -17,11 +18,11 @@ module ActiveWaiter
     end
 
     def write(uid, value)
-      Rails.cache.write("active_waiter:#{uid}", value)
+      ActiveWaiter.configuration.store.write(uid, value)
     end
 
     def read(uid)
-      Rails.cache.read("active_waiter:#{uid}")
+      ActiveWaiter.configuration.store.read(uid)
     end
   end
 end

--- a/lib/active_waiter/configuration.rb
+++ b/lib/active_waiter/configuration.rb
@@ -12,6 +12,10 @@ module ActiveWaiter
   end
 
   class Configuration
-    attr_accessor :layout
+    attr_accessor :layout, :store
+
+    def initialize
+      @store = ActiveWaiter::Store.new
+    end
   end
 end

--- a/lib/active_waiter/store.rb
+++ b/lib/active_waiter/store.rb
@@ -1,0 +1,11 @@
+module ActiveWaiter
+  class Store
+    def write(uid, value)
+      Rails.cache.write("active_waiter:#{uid}", value)
+    end
+
+    def read(uid)
+      Rails.cache.read("active_waiter:#{uid}")
+    end
+  end
+end

--- a/test/active_waiter/configuration_test.rb
+++ b/test/active_waiter/configuration_test.rb
@@ -1,5 +1,19 @@
 require 'test_helper'
 
+class TestStore
+  def initialize
+    @test_hash = {}
+  end
+
+  def write(uid, value)
+    @test_hash[uid] = value
+  end
+
+  def read(uid)
+    @test_hash[uid]
+  end
+end
+
 class ConfigurationTest < Minitest::Test
   def test_configuration_defaults
     assert_nil ActiveWaiter.configuration.layout
@@ -11,6 +25,18 @@ class ConfigurationTest < Minitest::Test
     end
 
     assert_equal "layouts/application", ActiveWaiter.configuration.layout
+  ensure
+    ActiveWaiter.configuration = nil
+  end
+
+  def test_configuration_store
+    test_store = TestStore.new
+    ActiveWaiter.configure do |config|
+      config.store = test_store
+    end
+
+    ActiveWaiter.write("abcdef", "test")
+    assert_equal "test", test_store.read("abcdef")
   ensure
     ActiveWaiter.configuration = nil
   end


### PR DESCRIPTION
There may be times when we don't want to use the Rails cache for tracking downloads, allow this aspect to be customized.
