### PR TITLE
Add Rails 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,14 @@ bundler_args: --retry=3 --jobs=8 --no-deployment
 cache: bundler
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2.2
-  - 2.2.1
-  - 2.2.0
+  - 2.2.5
+  - 2.2.6
+  - 2.3.0
+  - 2.3.1
+  - 2.3.2
+  - 2.3.3
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: 2.2.1
-    - rvm: 2.2.0
     - rvm: ruby-head
   fast_finish: true

--- a/active_waiter.gemspec
+++ b/active_waiter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.0"
 
-  s.add_dependency "rails", "~> 4.2.0"
+  s.add_dependency "rails", ">= 4.2", "< 5.1"
 
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-minitest"

--- a/active_waiter.gemspec
+++ b/active_waiter.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-minitest"
   s.add_development_dependency "rubocop"
+  s.add_development_dependency "rails-controller-testing"
 end

--- a/app/views/active_waiter/jobs/_reload.html.erb
+++ b/app/views/active_waiter/jobs/_reload.html.erb
@@ -1,3 +1,3 @@
 <script>
-  setTimeout(function() { window.location.href = <%= url_for(params.merge(retries: @retries)).to_json.html_safe %>; }, 2000);
+  setTimeout(function() { window.location.href = <%= url_for(params.permit!.merge(retries: @retries)).to_json.html_safe %>; }, 2000);
 </script>

--- a/lib/active_waiter/version.rb
+++ b/lib/active_waiter/version.rb
@@ -1,3 +1,3 @@
 module ActiveWaiter
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/test/controllers/active_waiter/jobs_controller_test.rb
+++ b/test/controllers/active_waiter/jobs_controller_test.rb
@@ -104,7 +104,7 @@ class ActiveWaiter::JobsControllerTest < ActionDispatch::IntegrationTest
   private
 
     def do_request(params)
-      get '/active_waiter', params
+      get '/active_waiter', params: params
     end
 
     def uid

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,9 @@ require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 # ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
 require "rails/test_help"
 
+require "rails-controller-testing"
+Rails::Controller::Testing.install
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
@choonkeat @winston This patch adds Rails 5.0 support, feel free to take a look 👀 ? 🙇 

Changes:
- Bump patch version
- Update gemspec to support Rails 5.0
- Fix Rails 5 breaking changes:
  - Stop calling hash-specific methods directly `params.merge`
  - Install rails-controller-testing gem so that integration tests can pass
- Fix Rails 5 deprecation warnings:
  - Use keyword argument when calling http request in integration tests e.g. `get params: params`

Also updated TravisCI to run tests on newer ruby versions, since many gems have dropped support on older ruby versions and causing tests to fail on TravisCI:
- 2.2.5
- 2.2.6
- 2.3.0
- 2.3.1
- 2.3.2
- 2.3.3
- ruby-head